### PR TITLE
Change Timestamp Style

### DIFF
--- a/hardware/src/api.py
+++ b/hardware/src/api.py
@@ -4,12 +4,13 @@ import datetime
 import json
 import logging
 from datetime import datetime
+import time
 import pytz
 from requests.exceptions import Timeout
 
 
 def get_time():
-    return datetime.now(pytz.timezone("Canada/Eastern"))
+    return time.time()
 
 def timestamp_data(value):
     return '{{"timestamp":{},"value":{}}}'.format(get_time(),value)


### PR DESCRIPTION
datetime.now(pytz.timezone("Canada/Eastern")) -> time.time()

Please complete the follow items before merging a pull request  

-   [ ] Ran Code locally
-   [ ] Updated any appropriate README files
-   [ ] Create a simple testbench (e.g a __main__ function)
-   [ ] Added Unit Testing 
-   [ ] Checked by at least 1 other person (please with comments if applicable)
-   [ ] Fixed any issues, or added new issues if not applicable 